### PR TITLE
Fix `--version` flag not showing correct version

### DIFF
--- a/patchwork/app.py
+++ b/patchwork/app.py
@@ -40,7 +40,7 @@ def _get_config_path(config: str, patchflow: str) -> tuple[Path | None, Path | N
         ignore_unknown_options=True,
     )
 )
-@click.version_option(message="%(version)s")
+@click.version_option(message="%(version)s", package_name="patchwork-cli")
 @click.help_option("-h", "--help")
 @click.option(
     "--log",


### PR DESCRIPTION
Issue is due to inequivalent package name and CLI name. By setting the package_name param to `patchwork-cli` `click` will now look for the correct package.