### PR TITLE
Support shallow detached repository

### DIFF
--- a/patchwork/steps/CommitChanges/CommitChanges.py
+++ b/patchwork/steps/CommitChanges/CommitChanges.py
@@ -2,7 +2,7 @@ import contextlib
 from pathlib import Path
 
 import git
-from git import Head, Repo
+from git import Head, Repo, RemoteReference
 from typing_extensions import Generator
 
 from patchwork.logger import logger
@@ -20,12 +20,13 @@ def get_slug_from_remote_url(remote_url: str) -> str:
     return potential_slug.removesuffix(".git")
 
 
-@contextlib.contextmanager
-def transitioning_branches(
-    repo: Repo, branch_prefix: str, branch_suffix: str = "", force: bool = True
-) -> Generator[tuple[Head, Head], None, None]:
+def get_current_branch(repo: Repo) -> RemoteReference | Head:
+    remote = repo.remote("origin")
     if repo.head.is_detached:
-        from_branch = next((branch for branch in repo.branches if branch.commit == repo.head.commit), None)
+        from_branch = next(
+            (branch for branch in remote.refs if branch.commit == repo.head.commit and branch.remote_head != "HEAD"),
+            None
+        )
     else:
         from_branch = repo.active_branch
 
@@ -35,16 +36,25 @@ def transitioning_branches(
             "Make sure repository is not in a detached HEAD state with additional commits."
         )
 
-    next_branch_name = f"{branch_prefix}{from_branch.name}{branch_suffix}"
+    return from_branch
+
+@contextlib.contextmanager
+def transitioning_branches(
+    repo: Repo, branch_prefix: str, branch_suffix: str = "", force: bool = True
+) -> Generator[tuple[str, str], None, None]:
+    from_branch = get_current_branch(repo)
+    next_branch_name = f"{branch_prefix}{from_branch.remote_head}{branch_suffix}"
     if next_branch_name in repo.heads and not force:
-        raise ValueError(f'Branch "{next_branch_name}" already exists.')
+        raise ValueError(f'Local Branch "{next_branch_name}" already exists.')
+    if next_branch_name in repo.remote("origin").refs and not force:
+        raise ValueError(f'Remote Branch "{next_branch_name}" already exists.')
 
     logger.info(f'Creating new branch "{next_branch_name}".')
     to_branch = repo.create_head(next_branch_name, force=force)
 
     try:
         to_branch.checkout()
-        yield from_branch, to_branch
+        yield from_branch.remote_head, next_branch_name
     finally:
         from_branch.checkout()
 
@@ -137,7 +147,7 @@ class CommitChanges(Step):
         repo = git.Repo(Path.cwd())
         if not self.enabled:
             logger.debug("Branch creation is disabled.")
-            return dict(target_branch=repo.active_branch.name)
+            return dict(target_branch=get_current_branch(repo).remote_head)
 
         modified_files = {modified_code_file["path"] for modified_code_file in self.modified_code_files}
 
@@ -153,6 +163,6 @@ class CommitChanges(Step):
 
             logger.info(f"Run completed {self.__class__.__name__}")
             return dict(
-                base_branch=from_branch.name,
-                target_branch=to_branch.name,
+                base_branch=from_branch,
+                target_branch=to_branch,
             )

--- a/patchwork/steps/CommitChanges/CommitChanges.py
+++ b/patchwork/steps/CommitChanges/CommitChanges.py
@@ -2,7 +2,7 @@ import contextlib
 from pathlib import Path
 
 import git
-from git import Head, Repo, RemoteReference
+from git import Head, Repo
 from typing_extensions import Generator
 
 from patchwork.logger import logger
@@ -20,12 +20,12 @@ def get_slug_from_remote_url(remote_url: str) -> str:
     return potential_slug.removesuffix(".git")
 
 
-def get_current_branch(repo: Repo) -> RemoteReference | Head:
+def get_current_branch(repo: Repo) -> Head:
     remote = repo.remote("origin")
     if repo.head.is_detached:
         from_branch = next(
             (branch for branch in remote.refs if branch.commit == repo.head.commit and branch.remote_head != "HEAD"),
-            None
+            None,
         )
     else:
         from_branch = repo.active_branch
@@ -37,6 +37,7 @@ def get_current_branch(repo: Repo) -> RemoteReference | Head:
         )
 
     return from_branch
+
 
 @contextlib.contextmanager
 def transitioning_branches(

--- a/poetry.lock
+++ b/poetry.lock
@@ -1640,13 +1640,13 @@ socks = ["socksio (==1.*)"]
 
 [[package]]
 name = "huggingface-hub"
-version = "0.23.1"
+version = "0.23.2"
 description = "Client library to download and publish models, datasets and other repos on the huggingface.co hub"
 optional = false
 python-versions = ">=3.8.0"
 files = [
-    {file = "huggingface_hub-0.23.1-py3-none-any.whl", hash = "sha256:720a5bffd2b1b449deb793da8b0df7a9390a7e238534d5a08c9fbcdecb1dd3cb"},
-    {file = "huggingface_hub-0.23.1.tar.gz", hash = "sha256:4f62dbf6ae94f400c6d3419485e52bce510591432a5248a65d0cb72e4d479eb4"},
+    {file = "huggingface_hub-0.23.2-py3-none-any.whl", hash = "sha256:48727a16e704d409c4bb5913613308499664f22a99743435dc3a13b23c485827"},
+    {file = "huggingface_hub-0.23.2.tar.gz", hash = "sha256:f6829b62d5fdecb452a76fdbec620cba4c1573655a8d710c1df71735fd9edbd2"},
 ]
 
 [package.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "patchwork-cli"
-version = "0.0.10"
+version = "0.0.11"
 description = ""
 authors = ["patched.codes"]
 license = "AGPL"


### PR DESCRIPTION
Usage of `repo.branches` should have been `repo.remotes.origin.refs` instead to be more consistent.