### PR TITLE
Improve handling of disable_pr option

### DIFF
--- a/patchwork/common/client/scm.py
+++ b/patchwork/common/client/scm.py
@@ -303,9 +303,10 @@ class GithubPullRequest(PullRequestProtocol):
 class GithubClient(ScmPlatformClientProtocol):
     DEFAULT_URL = Consts.DEFAULT_BASE_URL
 
-    def __init__(self, access_token: str, url: str = DEFAULT_URL):
+    def __init__(self, access_token: str, url: str = DEFAULT_URL, disable_pr: bool = False):
         self._access_token = access_token
         self._url = url
+        self.disable_pr = disable_pr
 
     @functools.cached_property
     def github(self) -> Github:
@@ -381,6 +382,11 @@ class GithubClient(ScmPlatformClientProtocol):
         original_branch: str,
         feature_branch: str,
     ) -> PullRequestProtocol:
+        if self.disable_pr:
+            logger.info("PR creation is disabled.")
+            return None
+
+
         # before creating a PR, check if one already exists
         repo = self.github.get_repo(slug)
         gh_pr = repo.create_pull(title=title, body=body, base=original_branch, head=feature_branch)
@@ -400,9 +406,10 @@ class GithubClient(ScmPlatformClientProtocol):
 class GitlabClient(ScmPlatformClientProtocol):
     DEFAULT_URL = gitlab.const.DEFAULT_URL
 
-    def __init__(self, access_token: str, url: str = DEFAULT_URL):
+    def __init__(self, access_token: str, url: str = DEFAULT_URL, disable_pr: bool = False):
         self._access_token = access_token
         self._url = url
+        self.disable_pr = disable_pr
 
     @functools.cached_property
     def gitlab(self) -> Gitlab:
@@ -489,6 +496,11 @@ class GitlabClient(ScmPlatformClientProtocol):
         original_branch: str,
         feature_branch: str,
     ) -> PullRequestProtocol:
+        if self.disable_pr:
+            logger.info("PR creation is disabled.")
+            return None
+
+
         # before creating a PR, check if one already exists
         project = self.gitlab.projects.get(slug)
         gl_mr = project.mergerequests.create(

--- a/patchwork/steps/CreatePR/CreatePR.py
+++ b/patchwork/steps/CreatePR/CreatePR.py
@@ -20,21 +20,26 @@ class CreatePR(Step):
 
         if not all(key in inputs.keys() for key in self.required_keys):
             raise ValueError(f'Missing required data: "{self.required_keys}"')
-
-        if "github_api_key" in inputs.keys():
-            self.scm_client = GithubClient(inputs["github_api_key"])
-        elif "gitlab_api_key" in inputs.keys():
-            self.scm_client = GitlabClient(inputs["gitlab_api_key"])
-        else:
-            raise ValueError(f'Missing required input data: "github_api_key" or "gitlab_api_key"')
-
-        if "scm_url" in inputs.keys():
-            self.scm_client.set_url(inputs["scm_url"])
-
-        if not self.scm_client.test():
-            raise ValueError(f"{self.scm_client.__class__.__name__} token test failed.")
-
+        
         self.enabled = not bool(inputs.get("disable_pr"))
+
+        if self.enabled:
+            if "github_api_key" in inputs.keys():
+                self.scm_client = GithubClient(inputs["github_api_key"])
+            elif "gitlab_api_key" in inputs.keys():
+                self.scm_client = GitlabClient(inputs["gitlab_api_key"])
+            else:
+                raise ValueError(f'Missing required input data: "github_api_key" or "gitlab_api_key"')
+
+            if "scm_url" in inputs.keys():
+                self.scm_client.set_url(inputs["scm_url"])
+
+            if not self.scm_client.test():
+                raise ValueError(f"{self.scm_client.__class__.__name__} token test failed.")
+        else:
+            if "github_api_key" in inputs.keys() or "gitlab_api_key" in inputs.keys():
+                logger.warn("PR creation is disabled. API keys provided will be ignored.")
+
         self.pr_body = inputs.get("pr_body", "")
         self.title = inputs.get("pr_title", "Patchwork PR")
         self.force = bool(inputs.get("force_pr_creation", False))

--- a/tests/steps/test_CreatePR.py
+++ b/tests/steps/test_CreatePR.py
@@ -1,0 +1,70 @@
+import pytest
+from patchwork.steps import CreatePR
+
+
+@pytest.fixture
+def create_pr_instance():
+    inputs = {
+        "github_api_key": "fake_key",
+        "scm_url": "https://github.com/user/repo",
+        "pr_body": "This is a test PR",
+        "pr_title": "Test PR",
+        "base_branch": "main",
+        "target_branch": "feature-branch"
+    }
+    return CreatePR(inputs)
+
+
+def test_pr_creation_enabled(create_pr_instance):
+    result = create_pr_instance.run()
+    assert "pr_url" in result
+
+
+def test_pr_creation_disabled():
+    inputs = {
+        "disable_pr": True,
+        "target_branch": "feature-branch"
+    }
+    create_pr_instance = CreatePR(inputs)
+    result = create_pr_instance.run()
+    assert result == {}
+
+
+def test_pr_creation_missing_api_keys():
+    inputs = {
+        "target_branch": "feature-branch"
+    }
+    with pytest.raises(ValueError):
+        CreatePR(inputs)
+
+
+def test_pr_creation_enabled_with_missing_base_branch():
+    inputs = {
+        "github_api_key": "fake_key",
+        "scm_url": "https://github.com/user/repo",
+        "pr_body": "This is a test PR",
+        "pr_title": "Test PR",
+        "target_branch": "feature-branch"
+    }
+    create_pr_instance = CreatePR(inputs)
+    result = create_pr_instance.run()
+    assert result == {}
+
+
+def test_pr_creation_same_base_and_target_branch():
+    inputs = {
+        "github_api_key": "fake_key",
+        "scm_url": "https://github.com/user/repo",
+        "pr_body": "This is a test PR",
+        "pr_title": "Test PR",
+        "base_branch": "feature-branch",
+        "target_branch": "feature-branch"
+    }
+    create_pr_instance = CreatePR(inputs)
+    result = create_pr_instance.run()
+    assert result == {}
+
+def test_pr_creation_with_force_flag(create_pr_instance):
+    create_pr_instance.force = True
+    result = create_pr_instance.run()
+    assert "pr_url" in result


### PR DESCRIPTION
This PR updates the scm.py and createPR.py files to handle the --disable_pr option. 

The main changes include:
Handling of --disable_pr Option:

a) scm.py: Adjusted logic to ensure that API keys are only required when disable_pr is set to False.

b) createPR.py: Updated the CreatePR class to:
                         Ignore API keys if disable_pr is set to True.
                         Log a warning when API keys are provided while PR creation is disabled.
                         Ensure that necessary validations are performed based on the disable_pr flag.

c) When disable_pr is True, API keys (GitHub or GitLab) provided in the input are ignored, and no PR creation attempt is made.

d) If disable_pr is False, the presence of valid API keys is validated, and PR creation proceeds if all other conditions are met.
These changes ensure that API keys are only required when PR creation is enabled.