### PR TITLE
Improve command construction by using extend instead of append

### DIFF
--- a/patchwork/steps/CallCode2Prompt/CallCode2Prompt.py
+++ b/patchwork/steps/CallCode2Prompt/CallCode2Prompt.py
@@ -38,8 +38,7 @@ class CallCode2Prompt(Step):
         ]
 
         if self.filter is not None:
-            cmd.append("--filter")
-            cmd.append(self.filter)
+            cmd.extend(["--filter", self.filter])
 
         if self.suppress_comments:
             cmd.append("--suppress-comments")


### PR DESCRIPTION
### Summary

This pull request improves the command construction by using `cmd.extend()` instead of multiple `cmd.append()` calls.

### Related Issue

Fixes #490 

### Details

The current implementation uses:
```python
cmd.append("--filter")
cmd.append(self.filter)
```
This has been changed to:
```python
cmd.extend(["--filter", self.filter])
```
**Benefits:**

- Reduces the number of method calls.
- Enhances code readability and maintainability.
- Slight performance improvement by reducing overhead.