### PR TITLE
Change cmd.append() to cmd.extend() for improved readability and fix subprocess error handling

### DIFF
--- a/patchwork/steps/CallCode2Prompt/CallCode2Prompt.py
+++ b/patchwork/steps/CallCode2Prompt/CallCode2Prompt.py
@@ -34,15 +34,17 @@ class CallCode2Prompt(Step):
         ]
 
         if self.filter is not None:
-            cmd.append("--filter")
-            cmd.append(self.filter)
+            cmd.extend(["--filter", self.filter])
 
         if self.suppress_comments:
             cmd.append("--suppress-comments")
 
-        p = subprocess.run(cmd, capture_output=True, text=True)
-
-        prompt_content_md = p.stdout
+        try:
+            p = subprocess.run(cmd, capture_output=True, text=True, check=True)
+            prompt_content_md = p.stdout
+        except subprocess.CalledProcessError as e:
+            self.set_status(StepStatus.FAILED, f"Subprocess failed: {e}")
+            return dict(files_to_patch=[])
 
         # Attempt to read the documentation's current content
         try:

--- a/patchwork/steps/ScanDepscan/ScanDepscan.py
+++ b/patchwork/steps/ScanDepscan/ScanDepscan.py
@@ -112,13 +112,22 @@ class ScanDepscan(Step):
             ]
 
             if self.language is not None:
-                cmd.append("-t")
-                cmd.append(self.language)
+                cmd.extend(["-t", self.language])
                 sbom_vdr_file_name = "sbom-" + self.language
             else:
                 sbom_vdr_file_name = "sbom-universal"
 
-            p = subprocess.run(cmd, capture_output=True, text=True, cwd=os.getcwd())
+            try:
+                p = subprocess.run(cmd, capture_output=True, text=True, cwd=os.getcwd())
+            except subprocess.CalledProcessError as e:
+                logger.debug("Command execution failed.")
+                logger.debug("stdout:\n" + e.stdout)
+                logger.debug("stderr:\n" + e.stderr)
+                raise RuntimeError("Subprocess command execution failed") from e
+            except Exception as e:
+                logger.debug("Unexpected error during command execution")
+                logger.debug(e)
+                raise RuntimeError("Unexpected error during Subprocess execution") from e
 
             sbom_vdr_file_path = Path(temp_file_path) / f"{sbom_vdr_file_name}.vdr.json"
             try:


### PR DESCRIPTION
Fixes Issue #490 
Change the usage of cmd.append() to cmd.extend() to improve readability and performance.

Currently, the CallCode2Prompt.py and ScanDepScan.py file uses multiple cmd.append() calls to add elements to the command list:
For e.g.
cmd.append("--filter")
cmd.append(self.filter)

This can be simplified to a single cmd.extend() call:

cmd.extend(["--filter", self.filter"])

Additionally, improved subprocess error handling to catch and handle subprocess.CalledProcessError and other exceptions more robustly.
