### PR TITLE
PatchWork GenerateDocstring

### DIFF
--- a/tests/cicd/generate_docstring/java_test_file.java
+++ b/tests/cicd/generate_docstring/java_test_file.java
@@ -7,6 +7,13 @@ class Test {
     * @return The sum of the two input integers
     */
     
+    /**
+    * Sums up two integers and returns the result.
+    * 
+    * @param a The first integer to be added
+    * @param b The second integer to be added
+    * @return The sum of the two input integers
+    */
     public static int a_plus_b(Integer a, Integer b) {
         return a + b;
     }

--- a/tests/cicd/generate_docstring/js_test_file.py.js
+++ b/tests/cicd/generate_docstring/js_test_file.py.js
@@ -24,6 +24,11 @@ const sqlite = (db, query, callback) => {
      * @returns {undefined} This method doesn't return a value
      */
     
+    /**
+     * Serializes the database operation by running the provided function within a transaction.
+     * @param {Function} callback - The function to be executed within the transaction.
+     * @returns {void} 
+     */
     db.serialize(function () {
         db.each(query, callback);
     });


### PR DESCRIPTION
This pull request from patchwork fixes 2 docstrings.

------

<div markdown="1">

* File changed: [tests/cicd/generate_docstring/js_test_file.py.js](https://github.com/patched-codes/patchwork/pull/672/files#diff-df2a5ce04cc3e12958b54827f37d550d2fb9a93ca4f2f1450da143e0264c169a)

</div>

<div markdown="1">

* File changed: [tests/cicd/generate_docstring/java_test_file.java](https://github.com/patched-codes/patchwork/pull/672/files#diff-c87470be45de8c3c06b3a0685e1dd157fdcc621ea184de508f0dbc534a0a7fed)

</div>