### PR TITLE
PatchWork AutoFix

### DIFF
--- a/patchwork/app.py
+++ b/patchwork/app.py
@@ -203,8 +203,12 @@ def cli(
             file.write(serialize(inputs))
 
 
-def find_patchflow(possible_module_paths: Iterable[str], patchflow: str) -> Any | None:
+def find_patchflow(possible_module_paths: Iterable[str], patchflow: str, whitelist: set[str]) -> Any | None:
     for module_path in possible_module_paths:
+        if module_path not in whitelist:
+            logger.debug(f"Module path {module_path} not in whitelist")
+            continue
+            
         try:
             spec = importlib.util.spec_from_file_location("custom_module", module_path)
             module = importlib.util.module_from_spec(spec)

--- a/patchwork/common/utils/dependency.py
+++ b/patchwork/common/utils/dependency.py
@@ -7,9 +7,12 @@ __DEPENDENCY_GROUPS = {
     "notification": ["slack_sdk"],
 }
 
+__WHITELIST = {"chromadb", "semgrep", "depscan", "slack_sdk"}
 
 @lru_cache(maxsize=None)
 def import_with_dependency_group(name):
+    if name not in __WHITELIST:
+        raise ImportError(f"Module {name} is not allowed.")
     try:
         return importlib.import_module(name)
     except ImportError:


### PR DESCRIPTION
This pull request from patched fixes 3 issues.

------

<div markdown="1">

* File changed: [patchwork/app.py](https://github.com/patched-codes/patchwork/pull/761/files#diff-839e90b808d34e4cf447eff0896161788ccfc6e1f2970be2e551b64ba413a503)<details><summary>Whitelist module paths for import to prevent arbitrary code execution</summary>  Added a whitelist to ensure that only approved module paths can be dynamically imported, preventing the execution of untrusted code.</details>

</div>

<div markdown="1">

* File changed: [patchwork/common/utils/step_typing.py](https://github.com/patched-codes/patchwork/pull/761/files#diff-4490efb269fda5b75b1edc5f5fa275d34675bca1ffbb22e06829384e562205ff)<details><summary>Fix unsafe usage of importlib.import_module with a hardcoded module path</summary>  Implemented a hardcoded list of allowed module paths (whitelist) to restrict dynamic input for importlib.import_module to load only trusted modules.</details>

</div>

<div markdown="1">

* File changed: [patchwork/common/utils/dependency.py](https://github.com/patched-codes/patchwork/pull/761/files#diff-6ad070db06c1de59a1e0b0b199944f057089f121f94abdf817a0845e3c5d81f6)<details><summary>Apply whitelist to input for `importlib.import_module` to prevent loading arbitrary code.</summary>  The code now uses a whitelist to restrict the modules that can be loaded by `importlib.import_module`, preventing arbitrary code execution through untrusted input.</details>

</div>