### PR TITLE
Fix last position and message truncation bug

### DIFF
--- a/patchwork/common/client/llm/protocol.py
+++ b/patchwork/common/client/llm/protocol.py
@@ -58,9 +58,11 @@ class LlmClient(Protocol):
 
         if last_message is not None:
 
-            def direction_callback(message: str) -> int:
+            def direction_callback(message_to_test: str) -> int:
+                current_messages = truncated_messages.copy()
+                current_messages.append({"content": message_to_test})
                 # add 500 as a safety margin
-                return client.is_prompt_supported([{"content": message}], model) - safety_margin
+                return client.is_prompt_supported(current_messages, model) - safety_margin
 
             last_message["content"] = LlmClient.__truncate_message(
                 message=last_message["content"],

--- a/patchwork/steps/ExtractCodeContexts/ExtractCodeContexts.py
+++ b/patchwork/steps/ExtractCodeContexts/ExtractCodeContexts.py
@@ -57,7 +57,7 @@ def get_source_code_contexts(
         for i in range(len(positions) - 1):
             if i in del_idxs:
                 continue
-            for j in range(i + 1, len(positions) - 1):
+            for j in range(i + 1, len(positions)):
                 if positions[i].end < positions[j].start:
                     break
                 del_idxs.append(j)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "patchwork-cli"
-version = "0.0.65"
+version = "0.0.66"
 description = ""
 authors = ["patched.codes"]
 license = "AGPL"

--- a/tests/cicd/generate_docstring/js_test_file.py.js
+++ b/tests/cicd/generate_docstring/js_test_file.py.js
@@ -3,13 +3,7 @@ function a_plus_b(a, b) {
     return a + b;
 }
 
-const sqlite = (db, query, callback) => {
-    db.serialize(function () {
-        db.each(query, callback);
-    });
-}
-
-const compare= function (keymap, a, b) {
+const compare = function (keymap, a, b) {
     if (a[keymap] < b[keymap]) {
         return -1;
     } else if (a[keymap] > b[keymap]) {
@@ -17,4 +11,10 @@ const compare= function (keymap, a, b) {
     } else {
         return 0;
     }
+}
+
+const sqlite = (db, query, callback) => {
+    db.serialize(function () {
+        db.each(query, callback);
+    });
 }


### PR DESCRIPTION
Last position bug:

Occurs when the last context is within another context, the last context will not be subsumed by the bigger context when `allow_overlap_contexts` is set to `False`.

Message truncation bug:

When calculating the token size of messages for deciding if the token size is too large or too small, only 1 message is used to calculate token size instead of all previous messages.