### PR TITLE
update readme and defaults docs

### DIFF
--- a/patchwork/patchflows/AutoFix/README.md
+++ b/patchwork/patchflows/AutoFix/README.md
@@ -14,7 +14,7 @@ by default you will need to provide the `openai_api_key` and the `github_api_key
 
 ## What it does?
 
-The AutoFix patchflow will first scan the code in your repository using an open-source scanner Semgrep. It will then take the vulnerabilities that are detected by the scan and create a prompt to be sent to `gpt-3.5-turbo` to generate the fix for the vulnerabilities. You can check the default [prompt template](./default_prompt.json). The generated fixes are then committed to the repository under a new branch and finally a pull request is created for the user to review and merge the changes. 
+The AutoFix patchflow will first scan the code in your repository using an open-source scanner Semgrep. It will then take the vulnerabilities that are detected by the scan and create a prompt to be sent to `gpt-4o` to generate the fix for the vulnerabilities. You can check the default [prompt template](./default_prompt.json). The generated fixes are then committed to the repository under a new branch and finally a pull request is created for the user to review and merge the changes. 
 
 ## Configuration
 
@@ -25,7 +25,7 @@ The following are the default configurations that can be modified by the user to
 You can choose any LLM API as long as it has an OpenAI API compatible chat completions endpoint. Just update the default values of the following options:
 
 ```yaml
-- model: gpt-3.5-turbo
+- model: gpt-4o
 - client_base_url: https://api.openai.com/v1
 ```
 

--- a/patchwork/patchflows/AutoFix/defaults.yml
+++ b/patchwork/patchflows/AutoFix/defaults.yml
@@ -14,7 +14,7 @@ severity: unknown
 # CallLLM Inputs
 # openai_api_key: required-for-chatgpt
 # google_api_key: required-for-gemini
-# model: gpt-3.5-turbo
+# model: gpt-4o
 # client_base_url: https://api.openai.com/v1
 # Example HF model
 # client_base_url: https://api-inference.huggingface.co/models/codellama/CodeLlama-70b-Instruct-hf/v1

--- a/patchwork/patchflows/DependencyUpgrade/README.md
+++ b/patchwork/patchflows/DependencyUpgrade/README.md
@@ -14,7 +14,7 @@ by default you will need to provide the `openai_api_key` and the `github_api_key
 
 ## What it does?
 
-The DependencyUpgrade patchflow will first scan your repository using an open-source scanner [dep-scan](https://github.com/owasp-dep-scan/dep-scan). It will then extract the vulnerable libraries information detected by the scan and use them to create a prompt to be sent to `gpt-3.5-turbo` to update your package manager file. You can check the default [prompt template](./dependency_upgrade_prompt.json). The fixed package manager file is then committed to the repository under a new branch and finally a pull request is created for the user to review and merge the changes. 
+The DependencyUpgrade patchflow will first scan your repository using an open-source scanner [dep-scan](https://github.com/owasp-dep-scan/dep-scan). It will then extract the vulnerable libraries information detected by the scan and use them to create a prompt to be sent to `gpt-4o` to update your package manager file. You can check the default [prompt template](./dependency_upgrade_prompt.json). The fixed package manager file is then committed to the repository under a new branch and finally a pull request is created for the user to review and merge the changes. 
 
 ## Configuration
 
@@ -25,7 +25,7 @@ The following are the default configurations that can be modified by the user to
 You can choose any LLM API as long as it has an OpenAI API compatible chat completions endpoint. Just update the default values of the following options:
 
 ```yaml
-- model: gpt-3.5-turbo
+- model: gpt-4o
 - client_base_url: https://api.openai.com/v1
 ```
 

--- a/patchwork/patchflows/DependencyUpgrade/defaults.yml
+++ b/patchwork/patchflows/DependencyUpgrade/defaults.yml
@@ -5,7 +5,7 @@ prompt_id: depupgrade
 # CallLLM Inputs
 # openai_api_key: required-for-chatgpt
 # google_api_key: required-for-gemini
-# model: gpt-3.5-turbo
+# model: gpt-4o
 # client_base_url: https://api.openai.com/v1
 # Example HF model
 # client_base_url: https://api-inference.huggingface.co/models/codellama/CodeLlama-70b-Instruct-hf/v1

--- a/patchwork/patchflows/GenerateDocstring/README.md
+++ b/patchwork/patchflows/GenerateDocstring/README.md
@@ -14,7 +14,7 @@ by default you will need to provide the `openai_api_key` and the `github_api_key
 
 ## What it does?
 
-The GenerateDocstring patchflow starts from a `base_path` (default is the current directory), recursively traverse the directory to extract methods from the source code files. It will then use them to create a prompt to be sent to `gpt-3.5-turbo` to update the source code with the docstrings. You can check the default [prompt template](./prompt.json). The udpated files are then committed to the repository under a new branch and finally a pull request is created for the user to review and merge the changes. 
+The GenerateDocstring patchflow starts from a `base_path` (default is the current directory), recursively traverse the directory to extract methods from the source code files. It will then use them to create a prompt to be sent to `gpt-4o` to update the source code with the docstrings. You can check the default [prompt template](./prompt.json). The udpated files are then committed to the repository under a new branch and finally a pull request is created for the user to review and merge the changes. 
 
 ## Configuration
 
@@ -25,7 +25,7 @@ The following are the default configurations that can be modified by the user to
 You can choose any LLM API as long as it has an OpenAI API compatible chat completions endpoint. Just update the default values of the following options:
 
 ```yaml
-- model: gpt-3.5-turbo
+- model: gpt-4o
 - client_base_url: https://api.openai.com/v1
 ```
 

--- a/patchwork/patchflows/GenerateDocstring/defaults.yml
+++ b/patchwork/patchflows/GenerateDocstring/defaults.yml
@@ -14,7 +14,7 @@ prompt_id: generate_docstring
 # openai_api_key: required-for-openai
 # google_api_key: required-for-google
 # client_base_url: https://api.openai.com/v1
-# model: gpt-3.5-turbo
+# model: gpt-4o
 
 # CommitChanges Inputs
 disable_branch: false

--- a/patchwork/patchflows/GenerateREADME/README.md
+++ b/patchwork/patchflows/GenerateREADME/README.md
@@ -14,7 +14,7 @@ by default you will need to provide the `openai_api_key` and the `github_api_key
 
 ## What it does?
 
-The GenerateREADME patchflow will first convert the folder into a markdown file using an open-source tool [code2prompt](https://github.com/raphaelmansuy/code2prompt). It will then use the file to create a prompt to be sent to `gpt-3.5-turbo` to generate a README.md file. You can check the default [prompt template](./generate_readme_prompt.json). The generated README.md file is then committed to the repository under a new branch and finally a pull request is created for the user to review and merge the changes. 
+The GenerateREADME patchflow will first convert the folder into a markdown file using an open-source tool [code2prompt](https://github.com/raphaelmansuy/code2prompt). It will then use the file to create a prompt to be sent to `gpt-4o` to generate a README.md file. You can check the default [prompt template](./generate_readme_prompt.json). The generated README.md file is then committed to the repository under a new branch and finally a pull request is created for the user to review and merge the changes. 
 
 ## Configuration
 
@@ -25,7 +25,7 @@ The following are the default configurations that can be modified by the user to
 You can choose any LLM API as long as it has an OpenAI API compatible chat completions endpoint. Just update the default values of the following options:
 
 ```yaml
-- model: gpt-3.5-turbo
+- model: gpt-4o
 - client_base_url: https://api.openai.com/v1
 ```
 

--- a/patchwork/patchflows/GenerateREADME/defaults.yml
+++ b/patchwork/patchflows/GenerateREADME/defaults.yml
@@ -4,7 +4,7 @@
 # CallLLM Inputs
 # openai_api_key: required-for-chatgpt
 # google_api_key: required-for-gemini
-# model: gpt-3.5-turbo
+# model: gpt-4o
 # client_base_url: https://api.openai.com/v1
 # Example HF model
 # client_base_url: https://api-inference.huggingface.co/models/codellama/CodeLlama-70b-Instruct-hf/v1

--- a/patchwork/patchflows/PRReview/README.md
+++ b/patchwork/patchflows/PRReview/README.md
@@ -14,7 +14,7 @@ by default you will need to provide the `openai_api_key` and the `github_api_key
 
 ## What it does?
 
-The PRReview patchflow will first read the PR. It will then extract the diff from the PR and use it to create a prompt to be sent to `gpt-3.5-turbo` to create a summary. You can check the default [prompt template](./pr_review_prompt.json). The PR summary is then added as a comment to the PR.
+The PRReview patchflow will first read the PR. It will then extract the diff from the PR and use it to create a prompt to be sent to `gpt-4o` to create a summary. You can check the default [prompt template](./pr_review_prompt.json). The PR summary is then added as a comment to the PR.
 
 ## Configuration
 
@@ -25,7 +25,7 @@ The following are the default configurations that can be modified by the user to
 You can choose any LLM API as long as it has an OpenAI API compatible chat completions endpoint. Just update the default values of the following options:
 
 ```yaml
-- model: gpt-3.5-turbo
+- model: gpt-4o
 - client_base_url: https://api.openai.com/v1
 ```
 

--- a/patchwork/patchflows/PRReview/defaults.yml
+++ b/patchwork/patchflows/PRReview/defaults.yml
@@ -14,7 +14,7 @@ diff_suggestion: false
 # CallLLM Inputs
 # openai_api_key: required-for-chatgpt
 # google_api_key: required-for-gemini
-# model: gpt-3.5-turbo
+# model: gpt-4o
 # client_base_url: https://api.openai.com/v1
 # Example HF model
 # client_base_url: https://api-inference.huggingface.co/models/codellama/CodeLlama-70b-Instruct-hf/v1

--- a/patchwork/patchflows/ResolveIssue/README.md
+++ b/patchwork/patchflows/ResolveIssue/README.md
@@ -32,7 +32,7 @@ fix_issue: true
 You can choose any LLM API as long as it has an OpenAI API compatible chat completions endpoint. Just update the default values of the following options:
 
 ```yaml
-model: gpt-3.5-turbo
+model: gpt-4o
 client_base_url: https://api.openai.com/v1
 ```
 

--- a/patchwork/patchflows/ResolveIssue/defaults.yml
+++ b/patchwork/patchflows/ResolveIssue/defaults.yml
@@ -13,7 +13,7 @@ fix_issue: false
 # openai_api_key: required-for-openai
 # google_api_key: required-for-google
 # client_base_url: https://api.openai.com/v1
-# model: gpt-3.5-turbo
+# model: gpt-4o
 
 # CommitChanges Inputs
 disable_branch: false


### PR DESCRIPTION
- Update the READMEs and default.yml for each patchflows to suggest using gpt-4o as the model instead of the older gpt-3.5-turbo.