### PR TITLE
Add paths to inputs of ScanSemgrep step

### DIFF
--- a/patchwork/common/utils/input_parsing.py
+++ b/patchwork/common/utils/input_parsing.py
@@ -7,7 +7,7 @@ __ITEM_TYPE = Union[AnyStr, Mapping]
 def __parse_to_list_handle_str(input_value: AnyStr, possible_delimiters: Iterable[AnyStr | None]) -> list[str]:
     for possible_delimiter in possible_delimiters:
         if possible_delimiter is None:
-            return input_value.strip()
+            return input_value.split()
 
         if possible_delimiter in input_value:
             return input_value.split(possible_delimiter)

--- a/patchwork/common/utils/input_parsing.py
+++ b/patchwork/common/utils/input_parsing.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+from typing_extensions import Union, AnyStr
+from collections.abc import Iterable, Mapping
+
+__ITEM_TYPE = Union[AnyStr, Mapping]
+
+def __parse_to_list_handle_str(input_value: AnyStr, possible_delimiters: Iterable[AnyStr | None]) -> list[str]:
+    for possible_delimiter in possible_delimiters:
+        if possible_delimiter is None:
+            return input_value.strip()
+
+        if possible_delimiter in input_value:
+            return input_value.split(possible_delimiter)
+
+    return []
+
+def __parse_to_list_handle_dict(input_value: Mapping, possible_keys: Iterable[AnyStr | None]) -> list[str]:
+    for possible_key in possible_keys:
+        if input_value.get(possible_key) is not None:
+            return input_value.get(possible_key)
+
+    return []
+
+def __parse_to_list_handle_iterable(input_value: Iterable[__ITEM_TYPE], possible_keys: Iterable[AnyStr | None]) -> list[str]:
+    rv = []
+    for item in input_value:
+        if isinstance(item, dict):
+            for possible_key in possible_keys:
+                if item.get(possible_key) is not None:
+                    rv.append(item.get(possible_key))
+        else:
+            rv.append(item)
+
+    return rv
+
+def parse_to_list(
+        input_value: __ITEM_TYPE | Iterable[__ITEM_TYPE],
+        possible_delimiters: Iterable[AnyStr | None] | None = None ,
+        possible_keys: Iterable[AnyStr | None] | None = None
+) -> list[str]:
+    if len(input_value) < 1:
+        return []
+
+    if possible_delimiters is None:
+        possible_delimiters = []
+    if possible_keys is None:
+        possible_keys = []
+
+    value_to_parse = []
+    if isinstance(value_to_parse, dict):
+        value_to_parse = __parse_to_list_handle_dict(input_value, possible_keys)
+    elif isinstance(value_to_parse, str):
+        value_to_parse = __parse_to_list_handle_str(value_to_parse, possible_delimiters)
+    elif isinstance(value_to_parse, Iterable):
+        value_to_parse = __parse_to_list_handle_iterable(input_value, possible_keys)
+
+    rv = []
+    for value in value_to_parse:
+        stripped_value = value.strip()
+        if stripped_value == "":
+            continue
+        rv.append(stripped_value)
+    return rv

--- a/patchwork/common/utils/input_parsing.py
+++ b/patchwork/common/utils/input_parsing.py
@@ -47,11 +47,11 @@ def parse_to_list(
         possible_keys = []
 
     value_to_parse = []
-    if isinstance(value_to_parse, dict):
+    if isinstance(input_value, dict):
         value_to_parse = __parse_to_list_handle_dict(input_value, possible_keys)
-    elif isinstance(value_to_parse, str):
-        value_to_parse = __parse_to_list_handle_str(value_to_parse, possible_delimiters)
-    elif isinstance(value_to_parse, Iterable):
+    elif isinstance(input_value, str):
+        value_to_parse = __parse_to_list_handle_str(input_value, possible_delimiters)
+    elif isinstance(input_value, Iterable):
         value_to_parse = __parse_to_list_handle_iterable(input_value, possible_keys)
 
     rv = []

--- a/patchwork/steps/ScanSemgrep/ScanSemgrep.py
+++ b/patchwork/steps/ScanSemgrep/ScanSemgrep.py
@@ -29,7 +29,8 @@ class ScanSemgrep(Step, input_class=ScanSemgrepInputs, output_class=ScanSemgrepO
         else:
             self.sarif_values = None
 
-        self.paths = parse_to_list(inputs.get("paths", ""), possible_delimiters=[",", None], possible_keys=["path"])
+        path_key = inputs.get("path_key", "path")
+        self.paths = parse_to_list(inputs.get("paths", ""), possible_delimiters=[",", None], possible_keys=[path_key])
 
     def run(self) -> dict:
         if self.sarif_values is not None:

--- a/patchwork/steps/ScanSemgrep/typed.py
+++ b/patchwork/steps/ScanSemgrep/typed.py
@@ -8,6 +8,7 @@ class ScanSemgrepInputs(TypedDict, total=False):
     sarif_values: str
     semgrep_extra_args: Annotated[str, StepTypeConfig(is_config=True)]
     paths: str
+    path_key: str
 
 
 class ScanSemgrepOutputs(TypedDict):

--- a/patchwork/steps/ScanSemgrep/typed.py
+++ b/patchwork/steps/ScanSemgrep/typed.py
@@ -7,6 +7,7 @@ class ScanSemgrepInputs(TypedDict, total=False):
     sarif_file_path: Annotated[str, StepTypeConfig(is_config=True, is_path=True)]
     sarif_values: str
     semgrep_extra_args: Annotated[str, StepTypeConfig(is_config=True)]
+    paths: str
 
 
 class ScanSemgrepOutputs(TypedDict):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "patchwork-cli"
-version = "0.0.68"
+version = "0.0.69"
 description = ""
 authors = ["patched.codes"]
 license = "AGPL"


### PR DESCRIPTION
Add a new `paths` input to `ScanSemgrep` step. This input is parsed by `parse_to_list` function which handles most cases of how we are dealing with very complex input possibilites.