### PR TITLE
Fix tool records giving path relative to base path.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,10 +16,10 @@ on:
       - resolveissue-*
       - demo*
 
-# Credits to https://blog.maximeheckel.com/posts/building-perfect-github-action-frontend-teams/
+# Credits to https://blog.maximeheckel.com/posts/building-perfect-github-action-frontend-teams/#you-are-terminated
 concurrency:
   # Here the group is defined by the head_ref of the PR
-  group: ${{ github.head_ref }}
+  group: ${{ github.head_ref || github.ref_name }}
   # Here we specify that we'll cancel any "in progress" workflow of the same group. Thus if we push, ammend a commit and push
   # again the previous workflow will be cancelled, thus saving us github action build minutes and avoid any conflicts
   cancel-in-progress: true

--- a/patchwork/common/tools/code_edit_tools.py
+++ b/patchwork/common/tools/code_edit_tools.py
@@ -104,13 +104,13 @@ Notes for using the `str_replace` command:
             return f"Error: {str(e)}"
 
         if command in {"create", "str_replace", "insert"}:
-            self.modified_files.update({abs_path.relative_to(self.repo_path)})
+            self.modified_files.update({abs_path})
 
         return result
 
     @property
     def tool_records(self):
-        return dict(modified_files=[{"path": str(file)} for file in self.modified_files])
+        return dict(modified_files=[file for file in self.modified_files])
 
     def __get_abs_path(self, path: str):
         wanted_path = Path(path).resolve()

--- a/patchwork/steps/FixIssue/FixIssue.py
+++ b/patchwork/steps/FixIssue/FixIssue.py
@@ -126,5 +126,7 @@ class FixIssue(Step, input_class=FixIssueInputs, output_class=FixIssueOutputs):
         self.multiturn_llm_call.execute(limit=100)
         for tool in self.multiturn_llm_call.tool_set.values():
             if isinstance(tool, CodeEditTool):
-                return tool.tool_records
+                cwd = Path.cwd()
+                modified_files = [file_path.relative_to(cwd) for file_path in tool.tool_records["modified_files"]]
+                return dict(modified_files=[{"path": str(file)} for file in modified_files])
         return dict()


### PR DESCRIPTION

## PR Checklist
<!-- Please check if your PR fulfills the following requirements: -->

- [x] The commit message follows our guidelines: [Code of conduct](https://github.com/patched-codes/patchwork/blob/main/CODE_OF_CONDUCT.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Does this PR introduce a breaking change?
- [x] Include PR in release notes?


## PR Type
<!-- What kind of change does this PR introduce? -->
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Build /CI
- [ ] Documentation
- [ ] Others


## What is the current behavior?
Currently paths are given relative to `base_path`

Issue Number: N/A


## What is the new behavior?

paths will be given relative to working directory instead.



## Other information