### PR TITLE
Add support for json_mode unsupported models

### DIFF
--- a/patchwork/steps/SimplifiedLLM/SimplifiedLLM.py
+++ b/patchwork/steps/SimplifiedLLM/SimplifiedLLM.py
@@ -57,7 +57,7 @@ class SimplifiedLLM(Step):
             raise e
 
     @staticmethod
-    def w(text: str) -> str:
+    def __extract_json_from_text(text: str) -> str:
         try:
             start = text.find("{")
             end = text.rfind("}")
@@ -79,7 +79,7 @@ class SimplifiedLLM(Step):
                 try:
                     # For models that don't support JSON mode, extract JSON from the text response first
                     if self.is_json_mode_unsupported:
-                        response = self.w(response)
+                        response = self.__extract_json_from_text(response)
 
                     json_response = self.__json_loads(response)
                     json_responses.append(json_response)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "patchwork-cli"
-version = "0.0.94"
+version = "0.0.95"
 description = ""
 authors = ["patched.codes"]
 license = "AGPL"


### PR DESCRIPTION
## PR Checklist
<!-- Please check if your PR fulfills the following requirements: -->

- [ ] The commit message follows our guidelines: [Code of conduct](https://github.com/patched-codes/patchwork/blob/main/CODE_OF_CONDUCT.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Does this PR introduce a breaking change?
- [ ] Include PR in release notes?


## PR Type
<!-- What kind of change does this PR introduce? -->
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring
- [ ] Build /CI
- [ ] Documentation
- [ ] Others


## What is the current behavior?

For models like `gemini-2.0-flash-thinking-exp`, there's a 400 error with no response.


## What is the new behavior?

Adds support for models that don't support json mode, which is needed to support `gemini-2.0-flash-thinking-exp`


## Other information