### PR TITLE
Fallback to gpt-4o for tiktoken if openai model unrecognized

### DIFF
--- a/patchwork/common/client/llm/openai_.py
+++ b/patchwork/common/client/llm/openai_.py
@@ -37,6 +37,7 @@ class OpenAiLlmClient(LlmClient):
         "o1-mini": 128_000,
         "gpt-4o-mini": 128_000,
         "gpt-4o": 128_000,
+        "o3-mini": 128_000,
     }
 
     def __init__(self, api_key: str, base_url=None, **kwargs):

--- a/patchwork/common/client/llm/openai_.py
+++ b/patchwork/common/client/llm/openai_.py
@@ -14,6 +14,7 @@ from openai.types.chat import (
 from typing_extensions import Dict, Iterable, List, Optional, Union
 
 from patchwork.common.client.llm.protocol import NOT_GIVEN, LlmClient, NotGiven
+from patchwork.logger import logger
 
 
 @functools.lru_cache
@@ -87,7 +88,12 @@ class OpenAiLlmClient(LlmClient):
 
         model_limit = self.__get_model_limits(model)
         token_count = 0
-        encoding = tiktoken.encoding_for_model(model)
+        encoding = None
+        try:
+            encoding = tiktoken.encoding_for_model(model)
+        except Exception as e:
+            logger.error(f"Error getting encoding for model {model}: {e}, using gpt-4o as fallback")
+            encoding = tiktoken.encoding_for_model("gpt-4o")
         for message in messages:
             message_token_count = len(encoding.encode(message.get("content")))
             token_count = token_count + message_token_count

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "patchwork-cli"
-version = "0.0.95"
+version = "0.0.96"
 description = ""
 authors = ["patched.codes"]
 license = "AGPL"


### PR DESCRIPTION
## PR Checklist
<!-- Please check if your PR fulfills the following requirements: -->

- [x] The commit message follows our guidelines: [Code of conduct](https://github.com/patched-codes/patchwork/blob/main/CODE_OF_CONDUCT.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Does this PR introduce a breaking change?
- [ ] Include PR in release notes?


## PR Type
<!-- What kind of change does this PR introduce? -->
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Build /CI
- [ ] Documentation
- [ ] Others


## What is the current behavior?

For o3-mini, tiktoken throws an unrecognized error. but there's no updated version of tiktoken which recognizes it.


## What is the new behavior?

We're using a fallback

## Other information